### PR TITLE
カメラ座標更新時のnilチェック追加と配列長の修正(ログ解析によるエラー処理)

### DIFF
--- a/serial.go
+++ b/serial.go
@@ -153,7 +153,7 @@ func prepareSendData() []byte {
 	sendbytes := sendarray.Bytes()
 
 	// 初回（データがない場合）は初期値を設定
-	if len(sendbytes) <= 0 {
+	if len(sendbytes) < 19 {
 		sendbytes = make([]byte, 19)
 		sendbytes[0] = 0xFF // プリアンブル
 		sendbytes[idxInfo] = 1
@@ -190,6 +190,12 @@ func prepareSendData() []byte {
 
 // updateCameraCoordinates はカメラ座標を更新する（一時的なゼロは無視）
 func updateCameraCoordinates(sendbytes []byte) {
+	//imageDataがnilの場合は安全に処理をスキップ（または0をセット）する。
+	if imageData == nil {
+		sendbytes[idxCamBallX] = 0
+		sendbytes[idxCamBallY] = 0
+		return
+	}
 	// X座標
 	if imageData.ImageX == 0 {
 		zeroCountX++


### PR DESCRIPTION
ログで表示されていたエラーである、バッテリー低下時などに発生していた、クラッシュを修正しました。あわせて、配列外参照による潜在的なバグも未然に防ぐ修正を入れています。

serial.goにおける2つの関数を修正しました。

 1. `updateCameraCoordinates` 関数の修正
修正内容: `imageData` を参照する前に `nil` チェック（`if imageData == nil`）を追加しました。
修正した理由: バッテリーアラーム（BATTERY ALARM）の発生時などに、カメラのデータが一時的に取得できず `nil` になることが原因で `nil pointer dereference` のパニックが発生し、システム全体が落ちていました。
`nil` の場合は安全に `0` をセットして処理をスキップすることで、ハードウェアや通信の不具合が起きてもプログラム全体がクラッシュしないようにしました。

2. `prepareSendData` 関数の修正
修正内容: 送信データの初期化条件を `len(sendbytes) <= 0` から `len(sendbytes) < 19` に変更しました。
修正した理由: 何らかの要因（並行処理の競合や書き込みの中断など）で、長さが1〜18バイトの中途半端なバッファが渡されてしまった場合、後続のインデックス指定（`sendbytes[16]`など）で `index out of range`（配列外参照）によるパニックが起きる危険性がありました。
これを防ぐため、規定の長さ（19バイト）を満たしていない場合は確実に初期化して安全を担保するようにしました。