### PR TITLE
#376 feat: Receive wheel encoder data from STM32 and forward to ssl-RAVEN

### DIFF
--- a/proto/pb_src/pi_to_mw.proto
+++ b/proto/pb_src/pi_to_mw.proto
@@ -15,6 +15,10 @@ message Robot_Status {
   required bool is_new_dribbler = 4;
   required uint32 battery_voltage  = 5;
   required uint32 cap_power  = 6;
+  optional float fl_wheel_speed = 7;
+  optional float bl_wheel_speed = 8;
+  optional float br_wheel_speed = 9;
+  optional float fr_wheel_speed = 10;
 }
 
 message Ball_Status {

--- a/send_to_ai.go
+++ b/send_to_ai.go
@@ -20,7 +20,8 @@ const (
 // createStatus はRACOON-MWに送信するステータスメッセージを作成する
 func createStatus(robotID uint32, detectPhotoSensor, detectDribbler, isNewDribbler bool,
 	batteryVoltage, capPower uint32, isBallExit bool, imageX, imageY float32,
-	minThreshold, maxThreshold string, ballDetectRadius int32, circularityThreshold float32) *pb_gen.PiToMw {
+	minThreshold, maxThreshold string, ballDetectRadius int32, circularityThreshold float32,
+	flWheelSpeed, blWheelSpeed, brWheelSpeed, frWheelSpeed float32) *pb_gen.PiToMw {
 	return &pb_gen.PiToMw{
 		RobotsStatus: &pb_gen.Robot_Status{
 			RobotId:                &robotID,
@@ -29,6 +30,10 @@ func createStatus(robotID uint32, detectPhotoSensor, detectDribbler, isNewDribbl
 			IsNewDribbler:          &isNewDribbler,
 			BatteryVoltage:         &batteryVoltage,
 			CapPower:               &capPower,
+			FlWheelSpeed:           &flWheelSpeed,
+			BlWheelSpeed:           &blWheelSpeed,
+			BrWheelSpeed:           &brWheelSpeed,
+			FrWheelSpeed:           &frWheelSpeed,
 		},
 		BallStatus: &pb_gen.Ball_Status{
 			IsBallExit:  &isBallExit,
@@ -126,6 +131,10 @@ func sendStatusToMW(conn net.Conn, myID uint32, adjustment Adjustment) {
 		adjustment.MaxThreshold,
 		int32(adjustment.BallDetectRadius),
 		adjustment.CircularityThreshold,
+		flWheelSpeedRadS,
+		blWheelSpeedRadS,
+		brWheelSpeedRadS,
+		frWheelSpeedRadS,
 	)
 
 	data, err := proto.Marshal(status)

--- a/serial.go
+++ b/serial.go
@@ -27,8 +27,8 @@ var (
 // ゼロ値の許容回数
 const zeroTolerance = 5
 
-// シリアル通信のプリアンブルパターン
-var serialPreamble = []byte{0xFF, 0x00, 0xFF, 0x00}
+// シリアル通信のプリアンブル（0xFF 1バイトのみ）
+var serialPreamble = []byte{0xFF}
 
 // 送信データのインデックス定数
 const (
@@ -89,9 +89,17 @@ func processSerialCommunication(port serial.Port) {
 		CheckError(err)
 	}
 
+	// ホイール回転数を100分の1に変換して rad/s の値にする
+	flWheelSpeedRadS = float32(recvdata.FlWheelSpeed) / 100.0
+	blWheelSpeedRadS = float32(recvdata.BlWheelSpeed) / 100.0
+	brWheelSpeedRadS = float32(recvdata.BrWheelSpeed) / 100.0
+	frWheelSpeedRadS = float32(recvdata.FrWheelSpeed) / 100.0
+
 	if debugSerial {
 		log.Printf("[Serial RX] Volt: %d (%.1fV), SensorInfo: 0b%08b, CapPower: %d",
 			recvdata.Volt, float32(recvdata.Volt)*0.1, recvdata.SensorInformation, recvdata.CapPower)
+		log.Printf("[Serial RX] Wheel(rad/s) FL: %.2f, BL: %.2f, BR: %.2f, FR: %.2f",
+			flWheelSpeedRadS, blWheelSpeedRadS, brWheelSpeedRadS, frWheelSpeedRadS)
 	}
 
 	// バッテリーエラーチェック
@@ -111,11 +119,11 @@ func processSerialCommunication(port serial.Port) {
 // waitForPreambleAndReceive はプリアンブルを検出してデータを受信する
 func waitForPreambleAndReceive(port serial.Port) []byte {
 	buf := make([]byte, 1)
-	recvbuf := make([]byte, 3)
+	recvbuf := make([]byte, 12)
 
 	port.ResetInputBuffer()
 
-	// プリアンブル検出（0xFF, 0x00, 0xFF, 0x00）
+	// プリアンブル検出（0xFF 1バイトのみ）
 	preambleIdx := 0
 	for preambleIdx < len(serialPreamble) {
 		port.Read(buf)
@@ -126,8 +134,8 @@ func waitForPreambleAndReceive(port serial.Port) []byte {
 		}
 	}
 
-	// データ受信（3バイト）
-	for i := 0; i < 3; i++ {
+	// データ受信（12バイト: Volt(1) + Sensor(1) + Cap(1) + FL(2) + BL(2) + BR(2) + FR(2) + Footer(1)）
+	for i := 0; i < 12; i++ {
 		port.Read(buf)
 		recvbuf[i] = buf[0]
 	}

--- a/variables.go
+++ b/variables.go
@@ -58,7 +58,20 @@ type RecvStruct struct {
 	Volt              uint8
 	SensorInformation uint8
 	CapPower          uint8
+	FlWheelSpeed      int16
+	BlWheelSpeed      int16
+	BrWheelSpeed      int16
+	FrWheelSpeed      int16
+	Footer            uint8
 }
+
+// ホイール回転数（rad/s）変換後の値
+var (
+	flWheelSpeedRadS float32
+	blWheelSpeedRadS float32
+	brWheelSpeedRadS float32
+	frWheelSpeedRadS float32
+)
 
 // センサー情報のビットマスク
 const (


### PR DESCRIPTION
- STM32とのシリアル通信フォーマットを12バイト（プリアンブル 0xFF）に更新
- 受信したホイール速度(int16)を 1/100 して float32 (rad/s) に変換する処理を追加
- protobuf (pi_to_mw) に速度フィールドを追加し、UDPパケットに付与して送信するように修正