### PR TITLE
Send robot NIC MAC address to RAVEN

### DIFF
--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -170,6 +170,12 @@ func getLocalIP() string {
 				continue
 			}
 			ip := ipNet.IP.String()
+			// 同じNICのMACアドレスを記録しておく。RAVEN側で各ロボットの基板を
+			// 一意に識別し、モータ個体差の管理に使う。
+			if mac := iface.HardwareAddr.String(); mac != "" {
+				state.MACAddress = mac
+				log.Printf("Local MAC for AI receive: %s (%s)", mac, iface.Name)
+			}
 			log.Printf("Local IP for AI receive: %s (%s)", ip, iface.Name)
 			return ip
 		}

--- a/internal/mw/mw.go
+++ b/internal/mw/mw.go
@@ -59,7 +59,7 @@ func createStatus(robotID uint32, detectPhotoSensor, detectDribbler, isNewDribbl
 	minThreshold, maxThreshold string, ballDetectRadius int32, circularityThreshold float32,
 	flWheelSpeed, blWheelSpeed, brWheelSpeed, frWheelSpeed float32) *pb_gen.PiToMw {
 	isNewRobot := state.IsNewRobot
-	return &pb_gen.PiToMw{
+	piToMw := &pb_gen.PiToMw{
 		IsNewRobot: &isNewRobot,
 		RobotsStatus: &pb_gen.Robot_Status{
 			RobotId:                &robotID,
@@ -85,6 +85,12 @@ func createStatus(robotID uint32, detectPhotoSensor, detectDribbler, isNewDribbl
 			CircularityThreshold: &circularityThreshold,
 		},
 	}
+	// MACアドレス(NIC由来)が取得できていれば付与する。
+	if state.MACAddress != "" {
+		mac := state.MACAddress
+		piToMw.MacAddress = &mac
+	}
+	return piToMw
 }
 
 func RunServer(done <-chan struct{}, myID uint32) {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -190,6 +190,12 @@ var (
 	// IsNewRobot is true when running on Rock5A (new robot) and false on
 	// Raspberry Pi (pi4). Set by the board-specific registerPlatform.
 	IsNewRobot bool = false
+
+	// MACAddress is the hardware (MAC) address of the active NIC, formatted as
+	// "aa:bb:cc:dd:ee:ff". Used by RAVEN to identify each robot's board for
+	// motor individual-difference management. Empty when it could not be
+	// resolved. Set once at startup alongside the local IP.
+	MACAddress string = ""
 )
 
 type Adjustment struct {

--- a/proto/pb_gen/pi_to_mw.pb.go
+++ b/proto/pb_gen/pi_to_mw.pb.go
@@ -27,7 +27,10 @@ type PiToMw struct {
 	BallStatus   *Ball_Status           `protobuf:"bytes,2,req,name=ball_status,json=ballStatus" json:"ball_status,omitempty"`
 	Ball         *Ball                  `protobuf:"bytes,3,req,name=ball" json:"ball,omitempty"`
 	// True when running on Rock5A (new robot), false on Raspberry Pi (pi4).
-	IsNewRobot    *bool `protobuf:"varint,4,req,name=is_new_robot,json=isNewRobot" json:"is_new_robot,omitempty"`
+	IsNewRobot *bool `protobuf:"varint,4,req,name=is_new_robot,json=isNewRobot" json:"is_new_robot,omitempty"`
+	// MACアドレス(NIC由来)。各ロボットの基板を一意に識別し、モータ個体差の
+	// 管理に使う。"aa:bb:cc:dd:ee:ff" 形式。取得できない場合は未設定。
+	MacAddress    *string `protobuf:"bytes,5,opt,name=mac_address,json=macAddress" json:"mac_address,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -88,6 +91,13 @@ func (x *PiToMw) GetIsNewRobot() bool {
 		return *x.IsNewRobot
 	}
 	return false
+}
+
+func (x *PiToMw) GetMacAddress() string {
+	if x != nil && x.MacAddress != nil {
+		return *x.MacAddress
+	}
+	return ""
 }
 
 type Robot_Status struct {
@@ -338,14 +348,16 @@ var File_pi_to_mw_proto protoreflect.FileDescriptor
 
 const file_pi_to_mw_proto_rawDesc = "" +
 	"\n" +
-	"\x0epi_to_mw.proto\"\xa8\x01\n" +
+	"\x0epi_to_mw.proto\"\xc9\x01\n" +
 	"\x06PiToMw\x122\n" +
 	"\rrobots_status\x18\x01 \x02(\v2\r.Robot_StatusR\frobotsStatus\x12-\n" +
 	"\vball_status\x18\x02 \x02(\v2\f.Ball_StatusR\n" +
 	"ballStatus\x12\x19\n" +
 	"\x04ball\x18\x03 \x02(\v2\x05.BallR\x04ball\x12 \n" +
 	"\fis_new_robot\x18\x04 \x02(\bR\n" +
-	"isNewRobot\"\x9f\x03\n" +
+	"isNewRobot\x12\x1f\n" +
+	"\vmac_address\x18\x05 \x01(\tR\n" +
+	"macAddress\"\x9f\x03\n" +
 	"\fRobot_Status\x12\x19\n" +
 	"\brobot_id\x18\x01 \x02(\rR\arobotId\x123\n" +
 	"\x16is_detect_photo_sensor\x18\x02 \x02(\bR\x13isDetectPhotoSensor\x129\n" +

--- a/proto/pb_src/pi_to_mw.proto
+++ b/proto/pb_src/pi_to_mw.proto
@@ -8,6 +8,9 @@ message PiToMw {
   required Ball ball = 3;
   // True when running on Rock5A (new robot), false on Raspberry Pi (pi4).
   required bool is_new_robot = 4;
+  // MACアドレス(NIC由来)。各ロボットの基板を一意に識別し、モータ個体差の
+  // 管理に使う。"aa:bb:cc:dd:ee:ff" 形式。取得できない場合は未設定。
+  optional string mac_address = 5;
 }
 
 message Robot_Status {


### PR DESCRIPTION
## 概要
起動時にアクティブな NIC(AI 受信に使う IP と同じ NIC)の MAC アドレスを取得し、RAVEN へ送信する。各ロボット基板(ラズパイ / Rock5A)を一意に識別し、モータ個体差の管理に使えるようにするため。

ペア PR: Rione/ssl-RAVEN#630 「Add robot NIC MAC address to RobotState」

## 変更内容
- `pi_to_mw.proto` に optional な `mac_address` フィールドを追加(生成コードも更新)
- 起動時にアクティブ NIC の MAC アドレスを取得して `state` に保持し、`PiToMw` で RAVEN へ送信
- MAC が取得できない場合は未設定で送信

🤖 Generated with [Claude Code](https://claude.com/claude-code)